### PR TITLE
Serve Obsidian vector store via FastAPI

### DIFF
--- a/Dockerfile.bot
+++ b/Dockerfile.bot
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "bot_service:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "obsidian_mcp_server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/bot.py
+++ b/bot.py
@@ -197,7 +197,7 @@ from langchain_chroma import Chroma
 from langchain_openai import OpenAIEmbeddings
 
 embeddings = OpenAIEmbeddings(model="text-embedding-3-large")
-OBSIDIAN_VAULT_PATH = "/Users/luisgg/tryingAI"  # Update this path
+OBSIDIAN_VAULT_PATH = os.environ.get("OBSIDIAN_VAULT", "/vault")
 vector_store = Chroma(
     collection_name="obsidian_jarvis",
     embedding_function=embeddings,
@@ -840,51 +840,49 @@ memory = MemorySaver()
 graph = graph_builder.compile(checkpointer=memory)
 
 # Run the graph
-def process_query(user_input):
-    """Process a user query through the graph."""
+def process_query(user_input: str) -> str:
+    """Process a user query through the graph and return the final AI message."""
     config = {
         "configurable": {
             "thread_id": "1",
-            "recursion_limit": 10  # Set a lower recursion limit
+            "recursion_limit": 10,
         }
     }
-    
+
     events = graph.stream(
         {
             "messages": [HumanMessage(content=user_input)],
-            "document_created": False,  # Initialize state
-            "WebResults": [],  # Initialize empty web results
-            "VaultFindings": [],  # Initialize empty vault findings
+            "document_created": False,
+            "WebResults": [],
+            "VaultFindings": [],
         },
         config,
         stream_mode="values",
     )
-    
-    # Process and display events
+
+    final_response = ""
     for event in events:
         if "messages" in event and event["messages"]:
             latest_message = event["messages"][-1]
             print(f"{latest_message.__class__.__name__}: {latest_message.content}")
-            
-            # Check for tool calls and display them
+
+            if isinstance(latest_message, AIMessage):
+                final_response = latest_message.content
+
             if hasattr(latest_message, "tool_calls") and latest_message.tool_calls:
                 for tool_call in latest_message.tool_calls:
                     tool_name = tool_call.get("name", "unknown_tool")
                     tool_args = tool_call.get("args", {})
                     print(f"Tool Call: {tool_name}")
                     print(f"Tool Args: {tool_args}")
-                    
-                    # If it's an update_vault_document call, print additional info
+
                     if tool_name == "update_vault_document":
                         title = tool_args.get("title", "Untitled")
                         print(f"Creating/Updating document: {title}")
-                        
-        # Check for other important state updates
+
         if "updated_file_path" in event:
             print(f"Document updated at: {event['updated_file_path']}")
         if "document_uuid" in event:
             print(f"Document UUID: {event['document_uuid']}")
 
-# Example usage
-if __name__ == "__main__":
-    process_query("me puedes dar una dieta de 1200 calorias?tengo el colon irritado por lo que alimentos especificos que ayuden serian buenos. no hay prisa tienes tiempo pero asegurate de crear las notas adecuadas")
+    return final_response

--- a/bot_service.py
+++ b/bot_service.py
@@ -1,0 +1,33 @@
+"""FastAPI service exposing the conversational bot and serving a basic UI."""
+
+import os
+from fastapi import FastAPI
+from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from bot import process_query
+
+app = FastAPI(title="Obsidian Bot Service")
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+
+class ChatRequest(BaseModel):
+    message: str
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index() -> HTMLResponse:
+    return FileResponse("static/index.html")
+
+
+@app.post("/chat")
+async def chat(req: ChatRequest) -> dict:
+    response = process_query(req.message)
+    return {"response": response}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", 8001)))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  bot:
+    build:
+      context: .
+      dockerfile: Dockerfile.bot
+    ports:
+      - "8001:8001"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OBSIDIAN_VAULT=/vault
+    volumes:
+      - ./vault:/vault
+  mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile.mcp
+    ports:
+      - "8000:8000"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OBSIDIAN_VAULT=/vault
+    volumes:
+      - ./vault:/vault

--- a/obsidian_mcp_server.py
+++ b/obsidian_mcp_server.py
@@ -1,0 +1,83 @@
+"""FastAPI server exposing Obsidian vector store operations.
+
+The server indexes an Obsidian vault into a Chroma vector store on startup.
+Endpoints are decorated for Model Context Protocol (MCP) compatibility so that
+LLM agents can call them as tools.
+"""
+
+import os
+from typing import List
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from obsidian_vectorstore import build_vector_store, delete_note
+
+try:  # Optional MCP decorator for tool exposure
+    from mcp import tool  # type: ignore
+except Exception:  # pragma: no cover - decorator is optional
+    def tool(*args, **kwargs):  # type: ignore
+        def decorator(func):
+            return func
+        return decorator
+
+
+VAULT_PATH = os.environ.get("OBSIDIAN_VAULT")
+if not VAULT_PATH:
+    raise RuntimeError("OBSIDIAN_VAULT environment variable not set")
+
+store = build_vector_store(VAULT_PATH)
+
+app = FastAPI(title="Obsidian Vector Store Server")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class SearchResult(BaseModel):
+    uuid: str
+    source: str
+    content: str
+
+
+@app.get("/search", response_model=List[SearchResult])
+@tool()
+def search(q: str, k: int = 4) -> List[SearchResult]:
+    """Return the top ``k`` chunks most similar to ``q``."""
+    results = store.similarity_search(q, k=k)
+    return [
+        SearchResult(
+            uuid=doc.metadata.get("uuid", ""),
+            source=doc.metadata.get("source", ""),
+            content=doc.page_content,
+        )
+        for doc in results
+    ]
+
+
+@app.post("/reindex")
+@tool()
+def reindex() -> dict:
+    """Rebuild the vector store from the vault."""
+    global store
+    store = build_vector_store(VAULT_PATH)
+    ids = store.get(include=[])["ids"]
+    return {"documents": len(ids)}
+
+
+@app.delete("/note/{note_uuid}")
+@tool()
+def remove_note(note_uuid: str) -> dict:
+    """Delete all embeddings associated with ``note_uuid``."""
+    delete_note(store, note_uuid)
+    return {"deleted": note_uuid}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", 8000)))

--- a/obsidian_vectorstore.py
+++ b/obsidian_vectorstore.py
@@ -1,0 +1,110 @@
+"""Utilities for indexing an Obsidian vault in a Chroma vector store.
+
+This module extracts the prototyping code that lived in the notebooks and
+turns it into reusable functions. Notes from an Obsidian vault are loaded,
+optionally split into chunks, and written to a persistent Chroma vector store.
+Each note is associated with a UUID that is stored both in the note's
+frontmatter and in the vector store so the note can later be updated or
+removed.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import yaml
+from langchain_chroma import Chroma
+from langchain_core.documents import Document
+from langchain_openai import OpenAIEmbeddings
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_community.document_loaders import ObsidianLoader
+
+
+def _ensure_uuid(file_path: Path, metadata: dict) -> str:
+    """Return the note UUID, inserting one into the file if missing."""
+    if "uuid" in metadata and metadata["uuid"]:
+        return metadata["uuid"]
+
+    note_uuid = str(uuid.uuid4())
+    text = file_path.read_text(encoding="utf-8")
+
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            frontmatter = yaml.safe_load(text[3:end]) or {}
+            frontmatter["uuid"] = note_uuid
+            new_frontmatter = yaml.safe_dump(frontmatter, sort_keys=False)
+            updated = f"---\n{new_frontmatter}---{text[end+4:]}"
+        else:
+            # Malformed frontmatter; prepend a new block
+            updated = f"---\nuuid: {note_uuid}\n---\n{text}"
+    else:
+        updated = f"---\nuuid: {note_uuid}\n---\n{text}"
+
+    file_path.write_text(updated, encoding="utf-8")
+    return note_uuid
+
+
+def load_and_split(vault_path: str) -> List[Tuple[str, Document]]:
+    """Load markdown notes from an Obsidian vault and split them.
+
+    Returns a list of tuples ``(chunk_id, Document)`` where ``chunk_id`` is
+    unique and encodes the originating note UUID and chunk index.
+    """
+    loader = ObsidianLoader(vault_path)
+    docs = loader.load()
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=1000, chunk_overlap=200, add_start_index=True
+    )
+
+    processed: List[Tuple[str, Document]] = []
+    for doc in docs:
+        source_path = doc.metadata.get("source")
+        if not source_path:
+            # Skip documents without a file source
+            continue
+        file_path = Path(source_path)
+        note_uuid = _ensure_uuid(file_path, doc.metadata)
+
+        for idx, chunk in enumerate(splitter.split_documents([doc])):
+            chunk.metadata["uuid"] = note_uuid
+            chunk.metadata["source"] = source_path
+            chunk_id = f"{note_uuid}:{idx}"
+            processed.append((chunk_id, chunk))
+    return processed
+
+
+def build_vector_store(
+    vault_path: str,
+    persist_directory: str = "./chroma_obsidian_db",
+    collection_name: str = "obsidian_docs",
+) -> Chroma:
+    """Create (or update) a Chroma vector store from an Obsidian vault."""
+    docs_with_ids = load_and_split(vault_path)
+    if not docs_with_ids:
+        raise ValueError("No documents were loaded from the vault")
+
+    ids, documents = zip(*docs_with_ids)
+    embeddings = OpenAIEmbeddings(model="text-embedding-3-large")
+    store = Chroma(
+        collection_name=collection_name,
+        embedding_function=embeddings,
+        persist_directory=persist_directory,
+    )
+    store.add_documents(list(documents), ids=list(ids))
+    return store
+
+
+def delete_note(store: Chroma, note_uuid: str) -> None:
+    """Remove all vector entries associated with ``note_uuid``."""
+    store.delete(where={"uuid": note_uuid})
+
+
+__all__ = [
+    "build_vector_store",
+    "delete_note",
+    "load_and_split",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn
+langchain-core
+langchain-community
+langchain-openai
+langchain-chroma
+langgraph
+chromadb
+python-dotenv
+pydantic

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Obsidian Vault Assistant</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 800px; margin: 2rem auto; }
+    textarea { width: 100%; height: 100px; }
+    pre { background: #f4f4f4; padding: 1rem; }
+    section { margin-bottom: 2rem; }
+  </style>
+</head>
+<body>
+  <h1>Obsidian Vault Assistant</h1>
+  <section>
+    <h2>Chat with Bot</h2>
+    <textarea id="query" placeholder="Ask something about your vault..."></textarea><br/>
+    <button onclick="sendQuery()">Send</button>
+    <pre id="response"></pre>
+  </section>
+  <section>
+    <h2>Search Vault</h2>
+    <input id="search" placeholder="Search query" />
+    <button onclick="searchVault()">Search</button>
+    <pre id="results"></pre>
+  </section>
+  <script>
+    async function sendQuery() {
+      const message = document.getElementById('query').value;
+      const res = await fetch('/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message })
+      });
+      const data = await res.json();
+      document.getElementById('response').textContent = data.response;
+    }
+
+    async function searchVault() {
+      const q = document.getElementById('search').value;
+      const res = await fetch('http://localhost:8000/search?q=' + encodeURIComponent(q));
+      const data = await res.json();
+      document.getElementById('results').textContent = JSON.stringify(data, null, 2);
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose conversational bot via FastAPI with basic HTML UI and configurable vault path
- containerize bot and MCP vector store server with separate Dockerfiles and docker-compose
- enable CORS and environment-based configuration for Obsidian vault access

## Testing
- `python -m py_compile bot.py bot_service.py obsidian_mcp_server.py obsidian_vectorstore.py`


------
https://chatgpt.com/codex/tasks/task_b_689797f8937c832c96d8293111ed80dd